### PR TITLE
Add support for connection token in update metadata

### DIFF
--- a/docs-v2/reference/api/connection/update-metadata.mdx
+++ b/docs-v2/reference/api/connection/update-metadata.mdx
@@ -5,7 +5,9 @@ openapi: 'PATCH /connection/metadata'
 
 ## Update _connection metadata_
 
-Nango uses the request body as the new metadata (it must be a JSON object). Note that this overrides specified properties, not the entire metadata. The connection_id must be passed in the body as well. Note that the connection_id can be a single string or an array of strings.
+Nango uses the request body as the new metadata (it must be a JSON object). Note that this overrides specified properties, not the entire metadata.
+
+You can either pass the `connection_id` or the `connection_token` in the body to update the metadata. Both can be either a single `string` or an `array` of strings.
 
 ## Fetching _connection metadata_
 

--- a/packages/server/lib/controllers/connection/updateMetadata.ts
+++ b/packages/server/lib/controllers/connection/updateMetadata.ts
@@ -1,17 +1,32 @@
 import { z } from 'zod';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
-import type { ApiError, UpdateMetadata, MetadataBody } from '@nangohq/types';
+import type { UpdateMetadata, Metadata, UpdateMetadataBody } from '@nangohq/types';
 import { connectionService } from '@nangohq/shared';
-import type { Connection } from '@nangohq/shared';
+import type { Response } from 'express';
 
 const validation = z
     .object({
-        connection_id: z.union([z.string().min(1), z.array(z.string().min(1))]),
-        provider_config_key: z.string().min(1),
+        connection_id: z.union([z.string().min(1), z.array(z.string().min(1))]).optional(),
+        connection_token: z.union([z.string().min(1), z.array(z.string().min(1))]).optional(),
+        provider_config_key: z.string().min(1).optional(),
         metadata: z.record(z.unknown())
     })
-    .strict();
+    .strict()
+    .refine(
+        (data) => {
+            if (data.connection_token || (Array.isArray(data.connection_token) && data.connection_token.length > 0)) {
+                return true;
+            }
+
+            const validConnectionId = data.connection_id || (Array.isArray(data.connection_id) && data.connection_id.length > 0);
+            return validConnectionId && data.provider_config_key;
+        },
+        {
+            message: 'Either connection_token or connection_id and data_provider_config_key must be provided',
+            path: ['connection_id', 'connection_token', 'data_provider_config_key']
+        }
+    );
 
 export const updateMetadata = asyncWrapper<UpdateMetadata>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
@@ -29,43 +44,64 @@ export const updateMetadata = asyncWrapper<UpdateMetadata>(async (req, res) => {
     }
 
     const { environment } = res.locals;
+    const { connectionIds, connectionTokens, providerConfigKey, metadata } = parseBody(val.data);
 
-    const body: Required<MetadataBody> = val.data;
-
-    const { connection_id: connectionIdArg, provider_config_key: providerConfigKey, metadata } = body;
-
-    const connectionIds = Array.isArray(connectionIdArg) ? connectionIdArg : [connectionIdArg];
-
-    const validConnections: Connection[] = [];
-
-    for (const connectionId of connectionIds) {
-        const { success, response: connection } = await connectionService.getConnection(connectionId, providerConfigKey, environment.id);
-
-        if (!success || !connection || !connection.id) {
-            const baseMessage = `Connection with connection id ${connectionId} and provider config key ${providerConfigKey} not found. Please make sure the connection exists in the Nango dashboard`;
-            const error: ApiError<'unknown_connection'> =
-                connectionIds.length > 1
-                    ? {
-                          error: {
-                              code: 'unknown_connection',
-                              message: `${baseMessage}. No actions were taken on any of the connections as a result of this failure.`
-                          }
-                      }
-                    : {
-                          error: {
-                              code: 'unknown_connection',
-                              message: baseMessage
-                          }
-                      };
-            res.status(404).json(error);
-
-            return;
-        }
-
-        validConnections.push(connection);
+    if (connectionTokens.length) {
+        await updateByConnectionToken(res, connectionTokens, metadata);
+    } else {
+        await updateByConnectionId(res, connectionIds, providerConfigKey, environment.id, metadata);
     }
-
-    await connectionService.updateMetadata(validConnections, metadata);
 
     res.status(200).send(req.body);
 });
+
+function parseBody(body: UpdateMetadataBody) {
+    const { connection_id: connectionIdArg, provider_config_key: providerConfigKey, connection_token: connectionTokenArg, metadata } = body;
+
+    return {
+        connectionIds: bodyParamToArray(connectionIdArg),
+        connectionTokens: bodyParamToArray(connectionTokenArg),
+        providerConfigKey,
+        metadata
+    };
+}
+
+function bodyParamToArray(param: string | string[] | undefined): string[] {
+    if (Array.isArray(param)) {
+        return param;
+    }
+
+    return param ? [param] : [];
+}
+
+async function updateByConnectionToken(res: Response, connectionTokens: string[], metadata: Metadata) {
+    const storedConnections = await connectionService.getConnectionsByTokens(connectionTokens);
+    if (storedConnections.length !== connectionTokens.length) {
+        const unkownTokens = connectionTokens.filter((token) => !storedConnections.find((conn) => conn.connection_token === token));
+        res.status(404).send({
+            error: {
+                code: 'unknown_connection',
+                message: `Connection with connection tokens: ${unkownTokens.join(', ')} not found. Please make sure the connection exists in the Nango dashboard. No actions were taken on any of the connections as a result of this failure.`
+            }
+        });
+        return;
+    }
+
+    await connectionService.updateMetadata(storedConnections, metadata);
+}
+
+async function updateByConnectionId(res: Response, connectionIds: string[], providerConfigKey: string | undefined, environmentId: number, metadata: Metadata) {
+    const storedConnections = await connectionService.getConnectionsByConnectionIds(connectionIds, providerConfigKey!, environmentId);
+    if (storedConnections.length !== connectionIds.length) {
+        const unknownIds = connectionIds.filter((connectionId) => !storedConnections.find((conn) => conn.connection_id === connectionId));
+        res.status(404).send({
+            error: {
+                code: 'unknown_connection',
+                message: `Connection with connection ids: ${unknownIds.join(', ')} and provider config key ${providerConfigKey} not found. Please make sure the connection exists in the Nango dashboard. No actions were taken on any of the connections as a result of this failure.`
+            }
+        });
+        return;
+    }
+
+    await connectionService.updateMetadata(storedConnections, metadata);
+}

--- a/packages/shared/lib/seeders/connection.seeder.ts
+++ b/packages/shared/lib/seeders/connection.seeder.ts
@@ -25,8 +25,10 @@ export const createConnectionSeeds = async (env: DBEnvironment): Promise<number[
 
 export const createConnectionSeed = async (env: DBEnvironment, provider: string): Promise<NangoConnection> => {
     const name = Math.random().toString(36).substring(7);
+    const connectionToken = crypto.randomUUID();
     const result = await connectionService.upsertConnection({
         connectionId: name,
+        connectionToken,
         providerConfigKey: provider,
         provider: 'google',
         parsedRawCredentials: {} as AuthCredentials,
@@ -39,7 +41,7 @@ export const createConnectionSeed = async (env: DBEnvironment, provider: string)
         throw new Error('Could not create connection seed');
     }
 
-    return { id: result[0].connection.id!, connection_id: name, provider_config_key: provider, environment_id: env.id };
+    return { id: result[0].connection.id!, connection_id: name, provider_config_key: provider, environment_id: env.id, connection_token: connectionToken };
 };
 
 export const deleteAllConnectionSeeds = async (): Promise<void> => {

--- a/packages/types/lib/connection/api/metadata.ts
+++ b/packages/types/lib/connection/api/metadata.ts
@@ -7,6 +7,13 @@ export interface MetadataBody {
     metadata: Metadata;
 }
 
+export interface UpdateMetadataBody {
+    connection_id?: string | string[] | undefined;
+    connection_token?: string | string[] | undefined;
+    provider_config_key?: string | undefined;
+    metadata: Metadata;
+}
+
 type MetadataError = ApiError<'invalid_body'> | ApiError<'unknown_connection'>;
 
 export type SetMetadata = Endpoint<{
@@ -20,7 +27,7 @@ export type SetMetadata = Endpoint<{
 export type UpdateMetadata = Endpoint<{
     Method: 'PATCH';
     Path: '/connection/metadata';
-    Body: MetadataBody;
+    Body: UpdateMetadataBody;
     Error: MetadataError;
-    Success: MetadataBody;
+    Success: UpdateMetadataBody;
 }>;


### PR DESCRIPTION
## Describe your changes
- Updated the `/connection/metadata` `PATCH` endpoint to support receiving either the `connectionId` and `providerId` pair or the `connectionToken`.
- Refactored the *UpdatedMetadata* file so that it won't make a database call inside of a `for` loop.
- Updated the integration tests.
- Updated the docs.

## Issue ticket number and link

## Checklist before requesting a review (skip if just adding/editing APIs & templates)
- [x] I added tests, otherwise the reason is: 
- [ ] I added observability, otherwise the reason is:
- [ ] I added analytics, otherwise the reason is: 
